### PR TITLE
Update golangci-lint and fix lint

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       GOOS: ${{ matrix.os }}
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: stable
       - uses: actions/checkout@v4

--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -36,7 +36,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: 'v1.53'
+          version: 'v1.55'
   # Runs golangci-lint on linux against linux and windows.
   golangci-linux:
     strategy:
@@ -54,4 +54,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: 'v1.53'
+          version: 'v1.55'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,10 +22,9 @@ linters:
     - structcheck
     - deadcode
     - ifshort
-    - rowserrcheck
-    - sqlclosecheck
-    - wastedassign
     - exhaustive
+    - tagalign
+    - depguard
 
 run:
   timeout: 3m

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 MIT LICENSE.
-Copyright (c) 2019-2023 Go Lift - Building Strong Go Tools
+Copyright (c) 2019-2024 Go Lift - Building Strong Go Tools
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/config_test.go
+++ b/config_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/cnfg"
 )
 
@@ -71,7 +72,7 @@ func TestUnmarshalText(t *testing.T) {
 	d := cnfg.Duration{Duration: time.Minute + time.Second}
 	b, err := d.MarshalText()
 
-	assert.Nil(t, err, "this method must not return an error")
+	require.NoError(t, err, "this method must not return an error")
 	assert.Equal(t, []byte("1m1s"), b)
 }
 
@@ -81,7 +82,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	d := cnfg.Duration{Duration: time.Minute + time.Hour}
 	b, err := d.MarshalJSON()
 
-	assert.Nil(t, err, "this method must not return an error")
+	require.NoError(t, err, "this method must not return an error")
 	assert.Equal(t, []byte(`"1h1m0s"`), b)
 }
 

--- a/env.go
+++ b/env.go
@@ -46,7 +46,7 @@ func MarshalENV(i interface{}, prefix string) (Pairs, error) {
 	return (&ENV{Pfx: prefix, Tag: ENVTag}).Marshal(i)
 }
 
-// Marshal converts deconstructs a data structure into environment variable pairs.
+// Marshal deconstructs a data structure into environment variable pairs.
 func (e *ENV) Marshal(i interface{}) (Pairs, error) {
 	value := reflect.ValueOf(i)
 	if value.Kind() != reflect.Ptr || value.Elem().Kind() != reflect.Struct {

--- a/map_test.go
+++ b/map_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/cnfg"
 )
 
@@ -26,18 +27,18 @@ func TestUnmarshalMap(t *testing.T) {
 	config := mapTester{}
 	worked, err := cnfg.UnmarshalMap(pairs, &config)
 
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.True(worked)
 	assert.EqualValues("bar", config.Foo)
 
 	worked, err = cnfg.UnmarshalMap(pairs, config)
 
 	assert.False(worked)
-	assert.NotNil(err, "must have an error when attempting unmarshal to non-pointer")
+	require.Error(t, err, "must have an error when attempting unmarshal to non-pointer")
 
 	worked, err = (&cnfg.ENV{}).UnmarshalMap(pairs, &config)
 	assert.True(worked)
-	assert.Nil(err)
+	require.NoError(t, err)
 }
 
 func ExampleUnmarshalMap() {

--- a/parse_test.go
+++ b/parse_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseInt(t *testing.T) {
@@ -13,11 +14,11 @@ func TestParseInt(t *testing.T) {
 
 	assert := assert.New(t)
 
-	for _, t := range []interface{}{int(0), int8(8), int16(16), int32(32), int64(64)} {
-		i, err := parseInt(t, fmt.Sprintf("%d", t))
+	for _, val := range []interface{}{int(0), int8(8), int16(16), int32(32), int64(64)} {
+		i, err := parseInt(val, fmt.Sprintf("%d", val))
 
+		require.NoError(t, err)
 		assert.EqualValues(t, i)
-		assert.NoError(err)
 	}
 }
 
@@ -34,7 +35,7 @@ func TestParseByteSlice(t *testing.T) { //nolint:paralleltest
 	ok, err := UnmarshalENV(testStruct, "D")
 
 	assert.True(ok)
-	assert.NoError(err)
+	require.NoError(t, err)
 	assert.Equal("byte slice incoming", string(testStruct.F))
 }
 
@@ -50,11 +51,10 @@ func TestParseUint(t *testing.T) {
 	embeddedInt := &test{}
 	theField := reflect.ValueOf(embeddedInt).Elem().Field(0)
 
-	for _, t := range []interface{}{uint(0), uint16(16), uint32(32), uint64(64)} {
-		err := parseUint(theField, t, "1")
-
+	for _, val := range []interface{}{uint(0), uint16(16), uint32(32), uint64(64)} {
+		err := parseUint(theField, val, "1")
+		require.NoError(t, err)
 		assert.EqualValues(1, embeddedInt.F)
-		assert.NoError(err)
 	}
 
 	type test2 struct {
@@ -65,14 +65,14 @@ func TestParseUint(t *testing.T) {
 	theField = reflect.ValueOf(testStruct).Elem().Field(0)
 
 	err := parseUint(theField, uint8(0), "11")
-	assert.NotNil(err, "must return an error when more than one byte is provided")
+	require.Error(t, err, "must return an error when more than one byte is provided")
 
 	err = parseUint(theField, uint8(0), "f")
-	assert.Nil(err, "must not return an error when only one byte is provided")
+	require.NoError(t, err, "must not return an error when only one byte is provided")
 	assert.Equal(byte('f'), testStruct.F)
 
 	err = parseUint(theField, uint8(0), "")
-	assert.Nil(err, "must not return an error when only no bytes are provided")
+	require.NoError(t, err, "must not return an error when only no bytes are provided")
 	assert.Equal(uint8(0), testStruct.F)
 }
 
@@ -85,6 +85,6 @@ func TestParseInterfaceError(t *testing.T) {
 	type F uint64
 
 	ok, err := (&parser{}).Interface(reflect.ValueOf(F(0)), "", "", false)
+	require.NoError(t, err, "unaddressable value must return nil")
 	assert.False(ok, "unaddressable value must return false")
-	assert.Nil(err, "unaddressable value must return nil")
 }

--- a/unparse_test.go
+++ b/unparse_test.go
@@ -3,13 +3,17 @@ package cnfg_test
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golift.io/cnfg"
 )
+
+const base10 = 10
 
 type MarshalTest struct {
 	Name  string                 `xml:"name,omitempty"`
@@ -87,7 +91,7 @@ func TestDeconStruct(t *testing.T) {
 	data, count := marshalTestData()
 	pairs, err := cnfg.MarshalENV(data, "PFX")
 
-	assert.Nil(err)
+	require.NoError(t, err)
 	assert.Equal(data.Name, pairs["PFX_NAME"])
 	assert.Equal(data.Pass, pairs["PFX_PASS"])
 	assert.Equal(data.IP.String(), pairs["PFX_IP"])
@@ -100,16 +104,16 @@ func TestDeconStruct(t *testing.T) {
 	assert.Equal(data.List[0], pairs["PFX_LIST_0"])
 	assert.Equal(data.List[1], pairs["PFX_LIST_1"])
 	assert.Equal(string(data.Byte), pairs["PFX_BYTE"])
-	assert.Equal(fmt.Sprintf("%d", data.Uint), pairs["PFX_UINT"])
-	assert.Equal(fmt.Sprintf("%d", data.Un16), pairs["PFX_UN16"])
-	assert.Equal(fmt.Sprintf("%d", data.Un32), pairs["PFX_UN32"])
-	assert.Equal(fmt.Sprintf("%d", data.Un64), pairs["PFX_UN64"])
+	assert.Equal(strconv.FormatUint(uint64(data.Uint), base10), pairs["PFX_UINT"])
+	assert.Equal(strconv.FormatUint(uint64(data.Un16), base10), pairs["PFX_UN16"])
+	assert.Equal(strconv.FormatUint(uint64(data.Un32), base10), pairs["PFX_UN32"])
+	assert.Equal(strconv.FormatUint(data.Un64, base10), pairs["PFX_UN64"])
 	assert.Equal(data.Dur.String(), pairs["PFX_DUR"])
-	assert.Equal(fmt.Sprintf("%d", data.Int), pairs["PFX_INT"])
-	assert.Equal(fmt.Sprintf("%d", data.In8), pairs["PFX_IN8"])
-	assert.Equal(fmt.Sprintf("%d", data.In16), pairs["PFX_IN16"])
-	assert.Equal(fmt.Sprintf("%d", data.In32), pairs["PFX_IN32"])
-	assert.Equal(fmt.Sprintf("%d", data.In64), pairs["PFX_IN64"])
+	assert.Equal(strconv.FormatInt(int64(data.Int), base10), pairs["PFX_INT"])
+	assert.Equal(strconv.FormatInt(int64(data.In8), base10), pairs["PFX_IN8"])
+	assert.Equal(strconv.FormatInt(int64(data.In16), base10), pairs["PFX_IN16"])
+	assert.Equal(strconv.FormatInt(int64(data.In32), base10), pairs["PFX_IN32"])
+	assert.Equal(strconv.FormatInt(data.In64, base10), pairs["PFX_IN64"])
 	assert.Equal("true", pairs["PFX_BOOL"])
 	assert.Equal(data.Test2.MarshalTest.Name, pairs["PFX_TEST2_NAME"])
 	assert.Equal(data.Test2.Name, pairs["PFX_TEST2_NAME"])
@@ -117,7 +121,7 @@ func TestDeconStruct(t *testing.T) {
 	assert.Equal("64.64", pairs["PFX_FL64"])
 	assert.Equal(data.Test.Name, pairs["PFX_TEST_NAME"])
 	assert.Equal(data.Test.Err.Error(), pairs["PFX_TEST_ERR"])
-	assert.Equal(count, len(pairs),
+	assert.Len(pairs, count,
 		fmt.Sprintf("%d variables are created in marshalTestData, update as more tests are added.", count))
 
 	for _, v := range pairs.Quoted() {


### PR DESCRIPTION
Updates golangci-lint and fixes a bunch of crap it found. It's still too stupid to run correctly in github actions. 

`typecheck max not found` makes since because the word max shows up no where in this repo.